### PR TITLE
fix: update description about kmod-ipv6

### DIFF
--- a/openwrt.md
+++ b/openwrt.md
@@ -19,12 +19,14 @@ OpenWRT IPv6 NAT 配置部分，由 [@Blaok](https://github.com/Blaok) 贡献。
 ### 零: 检查内核模块和有用的软件包
 
 ```
-ip6tables kmod-ipv6 kmod-ipt-nat6 kmod-ip6tables kmod-ip6tables-extra luci-proto-ipv6 iputils-traceroute6
+ip6tables kmod-ipt-nat6 kmod-ip6tables kmod-ip6tables-extra luci-proto-ipv6 iputils-traceroute6
 ```
+
+较新的OpenWrt已经内置了IPv6支持。对于较老的版本（Backfire 10.03 或 Attitude Adjustment 12.09及之前），还需要安装`kmod-ipv6`。
 
 `kmod`开头的内核模块一般无法通过opkg直接安装，其他软件包虽然可以通过`opkg install`直接安装，但会多占路由器存储空间，推荐在编译固件时就将这些软件包都放入固件
 
-上述软件包除`kmod-ipv6`外并非必须。`kmod-ipt-nat6`提供IPv6 NAT支持，`ip6tables kmod-ip6tables kmod-ip6tables-extra`等提供IPv6防火墙，`luci-proto-ipv6`为LuCI提供IPv6设置选项，`iputils-traceroute6`为IPv6提供traceroute功能(`mtr`是个不错的支持双栈的`traceroute`替代品，如果路由器存储空间够大的话)
+`kmod-ipt-nat6`提供IPv6 NAT支持，`ip6tables kmod-ip6tables kmod-ip6tables-extra`等提供IPv6防火墙，`luci-proto-ipv6`为LuCI提供IPv6设置选项，`iputils-traceroute6`为IPv6提供traceroute功能(`mtr`是个不错的支持双栈的`traceroute`替代品，如果路由器存储空间够大的话)
 
 ### 壹: 打开 OpenWRT IPv6 私网地址分配
 


### PR DESCRIPTION
OpenWrt在几年前已经完整内置了IPv6的支持，所以较新的版本不需要再安装`kmod-ipv6`这个包了，这个包也已经不存在啦。